### PR TITLE
specify an explicit registry for the controller image

### DIFF
--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -25,4 +25,4 @@ metadata:
       repo.
 spec:
   controller:
-    image: crossplane/provider-nop-controller:VERSION
+    image: index.docker.io/crossplane/provider-nop-controller:VERSION


### PR DESCRIPTION
### Description of your changes

This PR specifies an explicit registry for the controller image in the package metadata. A few things to note here:

* This is a PR to the `release-0.1` branch, which is not the current release.
* Specifying the `spec.controller.image` is an old way of building a provider package, but one that is still supported.  The latest version of this provider-nop has moved on from this old approach, e.g. https://github.com/crossplane-contrib/provider-nop/commit/7140449906250080528700b9bb863da43f0b3c9d#diff-f7a31bdfd654abb4b5d9ab577db3108eea7f9f242672d4c8b6caaf0d9fec6744
* The reason to do this is for e2e tests that are failing in the upstream Crossplane PR that changes the default registry: https://github.com/crossplane/crossplane/pull/5261
  * The e2e tests first install the old version `provider-nop:v0.1.1` then upgrades it to `v0.2.0`
  * This old `v0.1.1` provider specifies its `spec.controller.image` without specifying the registry.  Since the default registry is now changing, the package manager will try to install a package that doesn't exist in the new default registry.
  * This PR will make the registry explicit for this value, so it should all work smoothly 🤞 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

This will be tested as part of the upstream Crossplane e2e tests.

[contribution process]: https://git.io/fj2m9
