### PR TITLE
Always call SetLogger()

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -60,12 +60,7 @@ func main() {
 
 	zl := zap.New(zap.UseDevMode(*debug))
 	log := logging.NewLogrLogger(zl.WithName("provider-nop"))
-	if *debug {
-		// The controller-runtime runs with a no-op logger by default. It is
-		// *very* verbose even at info level, so we only provide it a real
-		// logger when we're running in debug mode.
-		ctrl.SetLogger(zl)
-	}
+	ctrl.SetLogger(zl)
 
 	log.Debug("Starting", "sync-period", syncInterval.String())
 


### PR DESCRIPTION
### Description of your changes
Always call ctrl.SetLogger() as required by controller-runtime

Fixes #17 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.
~- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.~

### How has this code been tested
Verified that the error message in the issue is not seen when the fix is applied

[contribution process]: https://git.io/fj2m9
