### PR TITLE
Publish to ghcr.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,14 +191,14 @@ jobs:
           install: true
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to Upbound
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != ''
         with:
           registry: xpkg.upbound.io
@@ -247,7 +247,7 @@ jobs:
           BUILD_ARGS: "--load"
 
       - name: Publish Artifacts to GitHub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: output
           path: _output/**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,13 @@ jobs:
           version: ${{ env.DOCKER_BUILDX_VERSION }}
           install: true
 
+      - name: Login to ghcr.io
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Login to Upbound
         uses: docker/login-action@v1
         if: env.UPBOUND_MARKETPLACE_PUSH_ROBOT_USR != ''

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ NPROCS ?= 1
 # to half the number of CPU cores.
 GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
-# If you change this, make sure to update .github/workflows/ci.yml as well, since it 
+# If you change this, make sure to update .github/workflows/ci.yml as well, since it
 # uses its own linter config.
 GOLANGCILINT_VERSION ?= 1.59.0
 GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
@@ -53,7 +53,7 @@ IMAGES = provider-nop
 # ====================================================================================
 # Setup XPKG
 
-XPKG_REG_ORGS ?= xpkg.upbound.io/crossplane-contrib
+XPKG_REG_ORGS ?= ghcr.io/crossplane-contrib xpkg.upbound.io/crossplane-contrib
 # NOTE(hasheddan): skip promoting on xpkg.upbound.io as channel tags are
 # inferred.
 XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/crossplane-contrib


### PR DESCRIPTION
### Description of your changes

This PR updates the `ci.yml` workflow to login to `ghcr.io` and then publish there in addition to the current location of `xpkg.upbound.io`.

This is for compliance with https://github.com/crossplane/crossplane/pull/6290, and also so that this provider is available on `ghcr.io` for crossplane e2e tests usage.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [x] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

I've run this CI in my fork and fixed a couple small issues (e.g. needing to bump older versions of some actions), but the publishing has not actually been exercised there since my fork can't push to the `crossplane-contrib` org. I'm not sure this can easily be tested from a fork actually.  It does help that it's very similar to #16 that removed publishing to dockerhub, so I have some confidence that in spirit this should work 😇 

[contribution process]: https://git.io/fj2m9
