### PR TITLE
update OWNERS with current maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -11,4 +11,10 @@ guidelines and responsibilities for the steering committee and maintainers.
 ## Maintainers
 
 * Nic Cope <negz@upbound.io> ([negz](https://github.com/negz))
+* Hasan Turken <hasan@upbound.io> ([turkenh](https://github.com/turkenh))
+* Philippe Scorsolini <philippe.scorsolini@upbound.io> ([phisco](https://github.com/phisco))
+* Jared Watts <jared@upbound.io> ([jbw976](https://github.com/jbw976))
+
+## Emeritus Maintainers
+
 * Daniel Mangum <dan@upbound.io> ([hasheddan](https://github.com/hasheddan))


### PR DESCRIPTION
### Description of your changes

This PR updates the OWNERS.md file to match what I currently see in the permissions/settings for folks that have maintainers+ access.  I believe this is the only part of the policies listed in #21 that this project still needs to complete.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] ~Added `backport release-x.y` labels to auto-backport this PR if necessary.~

[contribution process]: https://git.io/fj2m9
